### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -35,6 +35,7 @@ class ItemsController < ApplicationController
   end
 
   def destroy
+    redirect_to root_path unless current_user.id == @item.user_id
     @item.destroy
     redirect_to root_path
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit]
   before_action :item_find, only: [:show, :edit, :update, :destroy]
+  before_action :unless_user_id, only: [:edit, :destroy]
 
   def index
     @items = Item.all.order('created_at DESC')
@@ -23,7 +24,6 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    redirect_to root_path unless current_user.id == @item.user_id
   end
 
   def update
@@ -35,7 +35,6 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    redirect_to root_path unless current_user.id == @item.user_id
     @item.destroy
     redirect_to root_path
   end
@@ -49,5 +48,9 @@ class ItemsController < ApplicationController
 
   def item_find
     @item = Item.find(params[:id])
+  end
+
+  def unless_user_id
+    redirect_to root_path unless current_user.id == @item.user_id
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit]
-  before_action :item_find, only: [:show, :edit, :update]
+  before_action :item_find, only: [:show, :edit, :update, :destroy]
 
   def index
     @items = Item.all.order('created_at DESC')
@@ -32,6 +32,11 @@ class ItemsController < ApplicationController
     else
       render :edit
     end
+  end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
 
       <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
     <% elsif user_signed_in? %>
       <%# 商品が売れていない場合はこちらを表示しましょう %>
       <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items
 end


### PR DESCRIPTION
# What
出品者のみ商品削除可能な機能の実装
# Why
出品者のみが商品削除をできるようにするため

[ユーザーid1でログインしています。](https://gyazo.com/16efbe346d0c35dcc099c31029f93ee8)
DBはこのようになっています。（[削除前](https://gyazo.com/8dfca81601684cf4412c8232ed208f5c)、[削除後](https://gyazo.com/5928431173382160f50df670c4b7d133)）

[ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画](https://gyazo.com/2e2c36103149c914ab7738f3db5e2821)